### PR TITLE
Throw Win32Exception with last error code when Sendinput fails 

### DIFF
--- a/WindowsInput/WindowsInputMessageDispatcher.cs
+++ b/WindowsInput/WindowsInputMessageDispatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.InteropServices;
 using WindowsInput.Native;
 
@@ -15,14 +16,27 @@ namespace WindowsInput
         /// <param name="inputs">The list of <see cref="INPUT"/> messages to be dispatched.</param>
         /// <exception cref="ArgumentException">If the <paramref name="inputs"/> array is empty.</exception>
         /// <exception cref="ArgumentNullException">If the <paramref name="inputs"/> array is null.</exception>
-        /// <exception cref="Exception">If the any of the commands in the <paramref name="inputs"/> array could not be sent successfully.</exception>
+        /// <exception cref="Win32Exception">If the any of the commands in the <paramref name="inputs"/> array could not be sent successfully.</exception>
+        /// <exception cref="Exception">If the any of the commands in the <paramref name="inputs"/> array could not be sent successfully and <see 
+        /// cref="Marshal.GetLastWin32Error"></see> returns zero.</exception>
         public void DispatchInput(INPUT[] inputs)
         {
             if (inputs == null) throw new ArgumentNullException("inputs");
             if (inputs.Length == 0) throw new ArgumentException("The input array was empty", "inputs");
-            var successful = NativeMethods.SendInput((UInt32)inputs.Length, inputs, Marshal.SizeOf(typeof (INPUT)));
+            var successful = NativeMethods.SendInput((UInt32)inputs.Length, inputs, Marshal.SizeOf(typeof(INPUT)));
             if (successful != inputs.Length)
-                throw new Exception("Some simulated input commands were not sent successfully. The most common reason for this happening are the security features of Windows including User Interface Privacy Isolation (UIPI). Your application can only send commands to applications of the same or lower elevation. Similarly certain commands are restricted to Accessibility/UIAutomation applications. Refer to the project home page and the code samples for more information.");
+            {
+                //According to http://msdn.microsoft.com/en-us/library/windows/desktop/ms646310%28v=vs.85%29.aspx SendInput failures caused by UIPI are not indicated by GetLastError calls.
+                var lastWin32Error = Marshal.GetLastWin32Error();
+                if (lastWin32Error == 0)
+                {
+                    throw new Exception("Some simulated input commands were not sent successfully. The most common reason for this happening are the security features of Windows including User Interface Privacy Isolation (UIPI). Your application can only send commands to applications of the same or lower elevation. Similarly certain commands are restricted to Accessibility/UIAutomation applications. Refer to the project home page and the code samples for more information.");
+                }
+                else
+                {
+                    throw new Win32Exception(lastWin32Error);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Throwing Win32Exception exception has an advantage that it won't swallow the error code and it will automatically get the user friendly error message for the error that happened.

See https://blogs.msdn.com/b/adam_nathan/archive/2003/04/25/56643.aspx for details.
