### PR TITLE
Make drag/drop possible and add a test showing how it works.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ packages/
 
 #Test files
 *.testsettings
+.vs/

--- a/WindowsInput.Tests/InputSimulatorExamples.cs
+++ b/WindowsInput.Tests/InputSimulatorExamples.cs
@@ -100,7 +100,7 @@ namespace WindowsInput.Tests
 
             // get grab position in the title bar.
             int x = bounds.Left + (bounds.Width / 2);
-            int y = bounds.Top + 5;
+            int y = bounds.Top + 10;
 
             sim.Mouse
                .MoveMouseTo(x, y)

--- a/WindowsInput.Tests/NativeMethods/NativeMethods.cs
+++ b/WindowsInput.Tests/NativeMethods/NativeMethods.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace WindowsInput.Tests
+{
+    internal class NativeMethods
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        public struct POINT
+        {
+            int x;
+            public int y;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RECT
+        {
+            public int left;
+            public int top;
+            public int right;
+            public int bottom;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct WINDOWPLACEMENT
+        {
+            public UInt32 length;
+            public UInt32 flags;
+            public UInt32 showCmd;
+            public POINT ptMinPosition;
+            public POINT ptMaxPosition;
+            public RECT rcNormalPosition;
+            public RECT rcDevice;
+        }
+        ;
+        /// <summary>
+        /// Retrieves the show state and the restored, minimized, and maximized positions of the specified window.
+        /// </summary>
+        /// <param name="hwnd"></param>
+        /// <param name=""></param>
+        /// <param name=""></param>
+        /// <returns></returns>
+        [DllImport("user32.dll")]
+        public static extern bool GetWindowPlacement(IntPtr hwnd, ref WINDOWPLACEMENT placement);
+    }
+}

--- a/WindowsInput.Tests/WindowsInput.Tests.csproj
+++ b/WindowsInput.Tests/WindowsInput.Tests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.13.3\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" />
+  <Import Project="..\packages\NUnit3TestAdapter.4.3.1\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.4.3.1\build\net35\NUnit3TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,11 +12,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WindowsInput.Tests</RootNamespace>
     <AssemblyName>WindowsInput.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,8 +49,8 @@
     <Reference Include="HtmlAgilityPack">
       <HintPath>..\packages\HtmlAgilityPack.1.4.6\lib\Net45\HtmlAgilityPack.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.13.3\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -60,6 +64,7 @@
   <ItemGroup>
     <Compile Include="InputBuilderTests.cs" />
     <Compile Include="InputSimulatorExamples.cs" />
+    <Compile Include="NativeMethods\NativeMethods.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UnicodeText\UnicodeRange.cs" />
     <Compile Include="UnicodeText\UnicodeTestForm.cs">
@@ -87,6 +92,13 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.4.3.1\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.4.3.1\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.3\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/WindowsInput.Tests/packages.config
+++ b/WindowsInput.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net45" />
-  <package id="NUnit" version="2.6.2" targetFramework="net35" />
+  <package id="NUnit" version="3.13.3" targetFramework="net48" />
+  <package id="NUnit3TestAdapter" version="4.3.1" targetFramework="net48" />
 </packages>

--- a/WindowsInput/InputBuilder.cs
+++ b/WindowsInput/InputBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Windows.Forms;
 using WindowsInput.Native;
 
 namespace WindowsInput
@@ -262,16 +263,39 @@ namespace WindowsInput
             return AddCharacters(characters.ToCharArray());
         }
 
+        private UInt32 GetMouseButtonDownFlag(MouseButton button)
+        {
+            UInt32 flag = 0;
+            switch (button)
+            {
+                case MouseButton.None:
+                    break;
+                case MouseButton.LeftButton:
+                    flag = (UInt32)(MouseFlag.LeftDown);
+                    break;
+                case MouseButton.MiddleButton:
+                    flag = (UInt32)(MouseFlag.MiddleDown);
+                    break;
+                case MouseButton.RightButton:
+                    flag = (UInt32)(MouseFlag.RightDown);
+                    break;
+                default:
+                    break;
+            }
+            return flag;
+        }
+
         /// <summary>
         /// Moves the mouse relative to its current position.
         /// </summary>
         /// <param name="x"></param>
         /// <param name="y"></param>
+        /// <param name="button"></param>
         /// <returns>This <see cref="InputBuilder"/> instance.</returns>
-        public InputBuilder AddRelativeMouseMovement(int x, int y)
+        public InputBuilder AddRelativeMouseMovement(int x, int y, MouseButton button = MouseButton.None)
         {
             var movement = new INPUT { Type = (UInt32)InputType.Mouse };
-            movement.Data.Mouse.Flags = (UInt32)MouseFlag.Move;
+            movement.Data.Mouse.Flags = (UInt32)MouseFlag.Move | GetMouseButtonDownFlag(button);
             movement.Data.Mouse.X = x;
             movement.Data.Mouse.Y = y;
 
@@ -285,13 +309,19 @@ namespace WindowsInput
         /// </summary>
         /// <param name="absoluteX"></param>
         /// <param name="absoluteY"></param>
+        /// <param name="button"></param>
         /// <returns>This <see cref="InputBuilder"/> instance.</returns>
-        public InputBuilder AddAbsoluteMouseMovement(int absoluteX, int absoluteY)
-        {
+        public InputBuilder AddAbsoluteMouseMovement(int absoluteX, int absoluteY, MouseButton button = MouseButton.None)
+        { 
             var movement = new INPUT { Type = (UInt32)InputType.Mouse };
-            movement.Data.Mouse.Flags = (UInt32)(MouseFlag.Move | MouseFlag.Absolute);
-            movement.Data.Mouse.X = absoluteX;
-            movement.Data.Mouse.Y = absoluteY;
+            var flags = (UInt32)(MouseFlag.Move | MouseFlag.Absolute) | GetMouseButtonDownFlag(button);
+            var bounds = Screen.PrimaryScreen.WorkingArea;
+            var vx = absoluteX * 65535 / bounds.Width;
+            var vy = absoluteY * 65535 / bounds.Height;
+
+            movement.Data.Mouse.Flags = flags;
+            movement.Data.Mouse.X = vx;
+            movement.Data.Mouse.Y = vy;
 
             _inputList.Add(movement);
 
@@ -303,11 +333,13 @@ namespace WindowsInput
         /// </summary>
         /// <param name="absoluteX"></param>
         /// <param name="absoluteY"></param>
+        /// <param name="button"></param>
         /// <returns>This <see cref="InputBuilder"/> instance.</returns>
-        public InputBuilder AddAbsoluteMouseMovementOnVirtualDesktop(int absoluteX, int absoluteY)
+        public InputBuilder AddAbsoluteMouseMovementOnVirtualDesktop(int absoluteX, int absoluteY, MouseButton button = MouseButton.None)
         {
             var movement = new INPUT { Type = (UInt32)InputType.Mouse };
-            movement.Data.Mouse.Flags = (UInt32)(MouseFlag.Move | MouseFlag.Absolute | MouseFlag.VirtualDesk);
+            var flags = (UInt32)(MouseFlag.Move | MouseFlag.Absolute | MouseFlag.VirtualDesk) | GetMouseButtonDownFlag(button);           
+            movement.Data.Mouse.Flags = flags;
             movement.Data.Mouse.X = absoluteX;
             movement.Data.Mouse.Y = absoluteY;
 

--- a/WindowsInput/MouseButton.cs
+++ b/WindowsInput/MouseButton.cs
@@ -6,6 +6,10 @@
     public enum MouseButton
     {
         /// <summary>
+        /// No button selected.
+        /// </summary>
+        None,
+        /// <summary>
         /// Left mouse button
         /// </summary>
         LeftButton,

--- a/WindowsInput/MouseSimulator.cs
+++ b/WindowsInput/MouseSimulator.cs
@@ -10,7 +10,7 @@ namespace WindowsInput
     public class MouseSimulator : IMouseSimulator
     {
         private const int MouseWheelClickSize = 120;
-
+        private MouseButton mouseDown;
         private readonly IInputSimulator _inputSimulator;
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace WindowsInput
         /// <param name="pixelDeltaY">The distance in pixels to move the mouse vertically.</param>
         public IMouseSimulator MoveMouseBy(int pixelDeltaX, int pixelDeltaY)
         {
-            var inputList = new InputBuilder().AddRelativeMouseMovement(pixelDeltaX, pixelDeltaY).ToArray();
+            var inputList = new InputBuilder().AddRelativeMouseMovement(pixelDeltaX, pixelDeltaY, this.mouseDown).ToArray();
             SendSimulatedInput(inputList);
             return this;
         }
@@ -84,7 +84,7 @@ namespace WindowsInput
         /// <param name="absoluteY">The destination's absolute Y-coordinate on the primary display device where 0 is the top of the display device and 65535 is the bottom of the display device.</param>
         public IMouseSimulator MoveMouseTo(double absoluteX, double absoluteY)
         {
-            var inputList = new InputBuilder().AddAbsoluteMouseMovement((int)Math.Truncate(absoluteX), (int)Math.Truncate(absoluteY)).ToArray();
+            var inputList = new InputBuilder().AddAbsoluteMouseMovement((int)Math.Truncate(absoluteX), (int)Math.Truncate(absoluteY), this.mouseDown).ToArray();
             SendSimulatedInput(inputList);
             return this;
         }
@@ -96,7 +96,7 @@ namespace WindowsInput
         /// <param name="absoluteY">The destination's absolute Y-coordinate on the virtual desktop where 0 is the top of the virtual desktop and 65535 is the bottom of the virtual desktop.</param>
         public IMouseSimulator MoveMouseToPositionOnVirtualDesktop(double absoluteX, double absoluteY)
         {
-            var inputList = new InputBuilder().AddAbsoluteMouseMovementOnVirtualDesktop((int)Math.Truncate(absoluteX), (int)Math.Truncate(absoluteY)).ToArray();
+            var inputList = new InputBuilder().AddAbsoluteMouseMovementOnVirtualDesktop((int)Math.Truncate(absoluteX), (int)Math.Truncate(absoluteY), this.mouseDown).ToArray();
             SendSimulatedInput(inputList);
             return this;
         }
@@ -108,6 +108,7 @@ namespace WindowsInput
         {
             var inputList = new InputBuilder().AddMouseButtonDown(MouseButton.LeftButton).ToArray();
             SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.LeftButton;
             return this;
         }
 
@@ -118,6 +119,7 @@ namespace WindowsInput
         {
             var inputList = new InputBuilder().AddMouseButtonUp(MouseButton.LeftButton).ToArray();
             SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.None;
             return this;
         }
 
@@ -128,6 +130,7 @@ namespace WindowsInput
         {
             var inputList = new InputBuilder().AddMouseButtonClick(MouseButton.LeftButton).ToArray();
             SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.None;
             return this;
         }
 
@@ -138,6 +141,52 @@ namespace WindowsInput
         {
             var inputList = new InputBuilder().AddMouseButtonDoubleClick(MouseButton.LeftButton).ToArray();
             SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.None;
+            return this;
+        }
+
+
+        /// <summary>
+        /// Simulates a mouse middle button down gesture.
+        /// </summary>
+        public IMouseSimulator MiddleButtonDown()
+        {
+            var inputList = new InputBuilder().AddMouseButtonDown(MouseButton.MiddleButton).ToArray();
+            SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.MiddleButton;
+            return this;
+        }
+
+        /// <summary>
+        /// Simulates a mouse middle button up gesture.
+        /// </summary>
+        public IMouseSimulator MiddleButtonUp()
+        {
+            var inputList = new InputBuilder().AddMouseButtonUp(MouseButton.MiddleButton).ToArray();
+            SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.None;
+            return this;
+        }
+
+        /// <summary>
+        /// Simulates a mouse middle-click gesture.
+        /// </summary>
+        public IMouseSimulator MiddleButtonClick()
+        {
+            var inputList = new InputBuilder().AddMouseButtonClick(MouseButton.MiddleButton).ToArray();
+            SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.None;
+            return this;
+        }
+
+        /// <summary>
+        /// Simulates a mouse middle button double-click gesture.
+        /// </summary>
+        public IMouseSimulator MiddleButtonDoubleClick()
+        {
+            var inputList = new InputBuilder().AddMouseButtonDoubleClick(MouseButton.MiddleButton).ToArray();
+            SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.None;
             return this;
         }
 
@@ -148,6 +197,7 @@ namespace WindowsInput
         {
             var inputList = new InputBuilder().AddMouseButtonDown(MouseButton.RightButton).ToArray();
             SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.RightButton;
             return this;
         }
 
@@ -158,6 +208,7 @@ namespace WindowsInput
         {
             var inputList = new InputBuilder().AddMouseButtonUp(MouseButton.RightButton).ToArray();
             SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.None;
             return this;
         }
 
@@ -168,6 +219,7 @@ namespace WindowsInput
         {
             var inputList = new InputBuilder().AddMouseButtonClick(MouseButton.RightButton).ToArray();
             SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.None;
             return this;
         }
 
@@ -178,6 +230,7 @@ namespace WindowsInput
         {
             var inputList = new InputBuilder().AddMouseButtonDoubleClick(MouseButton.RightButton).ToArray();
             SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.None;
             return this;
         }
 
@@ -189,6 +242,7 @@ namespace WindowsInput
         {
             var inputList = new InputBuilder().AddMouseXButtonDown(buttonId).ToArray();
             SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.None;
             return this;
         }
 
@@ -200,6 +254,7 @@ namespace WindowsInput
         {
             var inputList = new InputBuilder().AddMouseXButtonUp(buttonId).ToArray();
             SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.None;
             return this;
         }
 
@@ -211,6 +266,7 @@ namespace WindowsInput
         {
             var inputList = new InputBuilder().AddMouseXButtonClick(buttonId).ToArray();
             SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.None;
             return this;
         }
 
@@ -222,6 +278,7 @@ namespace WindowsInput
         {
             var inputList = new InputBuilder().AddMouseXButtonDoubleClick(buttonId).ToArray();
             SendSimulatedInput(inputList);
+            this.mouseDown = MouseButton.None;
             return this;
         }
 

--- a/WindowsInput/WindowsInput.csproj
+++ b/WindowsInput/WindowsInput.csproj
@@ -50,6 +50,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IInputSimulator.cs" />


### PR DESCRIPTION
Make drag/drop possible and add a test showing how it works by keeping mouse down state during subsequent mouse movements.

Fix AddAbsoluteMouseMovement so it automatically virtualizes the coordinates (seems to be required on Windows 10 & 11 for it to work).

This also resolves the issue #8